### PR TITLE
Making Local Development Easy, Developers can now fork the current state of scroll sepolia to interact with the contract without any need of faucets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,14 @@ forge fmt
 ```
 
 
+You can use hardhat local nodes, it forkes current scroll sepolia state for local developement.
+```bash
+npx hardhat node
+```
+Run this command in `TNT/`, copy the private key and import the wallet on Metamask or any compatible wallet.
+Note- The chain is forked so it doesn't change the actual contract but works exactly the same and once the node is shut down everything is reset. 
+Local RPC endpoint 
+http://127.0.0.1:8545
 
 ---
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -11,7 +11,20 @@ module.exports = {
   },
   networks: {
     hardhat: {
-      allowUnlimitedContractSize: true
+      allowUnlimitedContractSize: true,
+      forking: {
+        // Use a public RPC or your own provider URL for Scroll Sepolia
+        url:  process.env.SCROLL_SEPOLIA_RPC_URL || "https://scroll-sepolia.drpc.org", 
+        // Optional: Specify a block number to fork from for deterministic tests
+        // blockNumber: 1234567 
+      },
+      accounts: {
+        mnemonic: "test test test test test test test test test test test junk",
+        path: "m/44'/60'/0'/0",
+        initialIndex: 0,
+        count: 10, // Generates 10 funded wallets
+        accountsBalance: "10000000000000000000000", // 10,000 ETH in wei
+      },
     }
   }
 };

--- a/web/src/utils/address.ts
+++ b/web/src/utils/address.ts
@@ -1,5 +1,6 @@
 export const TNTVaultFactories = {
   534351: "0xc0e8ababc172112e3e458ae35a4d2d4b92b35e8e",
+  31337: "0xc0e8ababc172112e3e458ae35a4d2d4b92b35e8e",
   // 61: "0x3936A2281A4585E7Bee5710839D0F29fBAF3Fc77",
 } as {
   [key: number]: `0x${string}`;

--- a/web/src/utils/config.tsx
+++ b/web/src/utils/config.tsx
@@ -1,10 +1,11 @@
-import { mainnet, polygon, scrollSepolia } from "wagmi/chains";
+import { mainnet, polygon, scrollSepolia, hardhat } from "wagmi/chains";
 import { getDefaultConfig } from "@rainbow-me/rainbowkit";
 import { citreaTestnet } from "@/components/CitreaTestnet";
 import { ethereumClassic } from "@/components/EthereumClassic";
 
 const chains = [
   scrollSepolia,
+  hardhat,
   polygon,
   mainnet,
   citreaTestnet,


### PR DESCRIPTION
### Addressed Issues:

This PR is an independent contribution that improves the local development and testing workflow by adding a Hardhat configuration for forking Scroll Sepolia.

Currently, interacting with contracts already deployed on Scroll Sepolia during local development requires developers to use the live testnet and obtain testnet funds. The added fork configuration allows developers to work with the existing Scroll Sepolia contract state locally using funded Hardhat accounts.

### Screenshots/Recordings:

Not applicable. This PR contains development and configuration changes without UI changes.

### Additional Notes:

The Hardhat fork can be started using:

```bash
npx hardhat node
```

The fork provides a local RPC endpoint at:
http://127.0.0.1:8545
Add the private key to any suitable wallet you have, with RPC mentioned above and Chain Id 31337
This allows the frontend to interact with contracts deployed on Scroll Sepolia while keeping all transactions local to the fork.


Check one of the checkboxes below:

- [x] This PR does not contain AI-generated code at all.
- [ ] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.



## Checklist
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [ ] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.
